### PR TITLE
Optimise font loading

### DIFF
--- a/assets/js/src/fonts.js
+++ b/assets/js/src/fonts.js
@@ -1,0 +1,31 @@
+"use strict";
+
+(function (w) {
+    if (w.document.documentElement.className.indexOf("fonts-loaded") > -1) {
+        return;
+    }
+    var font1 = new w.FontFaceObserver("Raleway", {
+        weight: 400
+    });
+
+    var font2 = new w.FontFaceObserver("Raleway", {
+        weight: 700
+    });
+
+    var font3 = new w.FontFaceObserver("Roboto Slab", {
+        weight: 300
+    });
+
+    var font4 = new w.FontFaceObserver("Roboto Slab", {
+        weight: 400
+    });
+
+    w.Promise
+        .all([font1.check(), font2.check(), font3.check(), font4.check()])
+        .then(function () {
+            w.document.documentElement.className += " fonts-loaded";
+        })
+        .catch(function(){
+            w.document.documentElement.className += " fonts-unavailable";
+        });
+} (this));

--- a/assets/js/src/fonts.js
+++ b/assets/js/src/fonts.js
@@ -1,9 +1,6 @@
 "use strict";
 
 (function (w) {
-    if (w.document.documentElement.className.indexOf("fonts-loaded") > -1) {
-        return;
-    }
     var font1 = new w.FontFaceObserver("Raleway", {
         weight: 400
     });
@@ -23,9 +20,19 @@
     w.Promise
         .all([font1.check(), font2.check(), font3.check(), font4.check()])
         .then(function () {
-            w.document.documentElement.className += " fonts-loaded";
+            if (w.document.documentElement.className.indexOf("fonts-loaded") == -1) {
+                w.document.documentElement.className += " fonts-loaded";
+            }
+            try {
+                var storage = window.sessionStorage;
+                if (storage) {
+                    storage.setItem('fonts-loaded', '1');
+                }
+            }
+            catch (e) {
+            }
         })
-        .catch(function(){
+        .catch(function () {
             w.document.documentElement.className += " fonts-unavailable";
         });
 } (this));

--- a/assets/scss/modules/_global.scss
+++ b/assets/scss/modules/_global.scss
@@ -16,9 +16,13 @@ body {
 }
 
 body {
-    font-family: $sans-font;
+    font-family: $sans-font-fallback;
     color: $gray-darker;
     background: $gray-lighter;
+}
+
+.fonts-loaded body {
+    font-family: $sans-font;
 }
 
 mark {
@@ -51,11 +55,19 @@ h2,
 h3,
 h4,
 h5,
-h5 {
-    font-family: $serif-font;
+h6 {
+    font-family: $serif-font-fallback;
     -webkit-font-smoothing: antialiased;
     font-weight: lighter;
     color: $gray-darkest;
+}
+
+.fonts-loaded h1,
+.fonts-loaded h2,
+.fonts-loaded h3,
+.fonts-loaded h4,
+.fonts-loaded h6 {
+    font-family: $serif-font;
 }
 
 h1 {
@@ -92,9 +104,13 @@ h6 {
 p {
     margin-bottom: 20px;
     line-height: 26px;
+    font-size: 90%;
     > code {
         @include inline-code-style;
     }
+}
+.fonts-loaded p{
+    font-size: 100%;
 }
 
 strong {

--- a/assets/scss/modules/_variables.scss
+++ b/assets/scss/modules/_variables.scss
@@ -33,7 +33,9 @@ $divider-color         : rgba(255, 255, 255, .14);
 $unit                  : 1rem;
 
 $sans-font             : 'Raleway', sans-serif;
-$serif-font            : 'Roboto Slab', serif;
+$sans-font-fallback  : Geneva, sans-serif;
+$serif-font            : 'Roboto Slab', Georgia, serif;
+$serif-font-fallback   : Georgia, serif;
 $code-font             : Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
 $quote-font            : "freight-text-pro", Georgia, Cambria, "Times New Roman", Times, serif;
 

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "prism": "~1.3.0",
     "bourbon": "~4.2.6",
     "toastr": "^2.1.2",
-    "store-js": "^1.3.20"
+    "store-js": "^1.3.20",
+    "fontfaceobserver": "^1.7.1"
   },
   "ignore": [
     "**/.*",

--- a/default.hbs
+++ b/default.hbs
@@ -11,6 +11,7 @@
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400" />
         <link rel="stylesheet" type="text/css" href="{{asset "css/caffeine-theme.css"}}" />
         {{ghost_head}}
+        {{> headscript}}
     </head>
     <body class="{{body_class}}">
         {{> header}}

--- a/default.hbs
+++ b/default.hbs
@@ -8,6 +8,7 @@
         <![endif]-->
         <title>{{meta_title}}</title>
         {{> meta}}
+        <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400" />
         <link rel="stylesheet" type="text/css" href="{{asset "css/caffeine-theme.css"}}" />
         {{ghost_head}}
     </head>
@@ -23,7 +24,6 @@
         {{> tags-overlay}}
         {{ghost_foot}}
         <script src="{{asset "js/caffeine-theme.js"}}" type="text/javascript" charset="utf-8"></script>
-        <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400" />
         {{> google-analytics}}
         {{> disqus-comment-count}}
     </body>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,10 @@ src = {
         files: ["assets/scss/**/**"]
     },
     js: {
+        fonts: [
+            "assets/vendor/fontfaceobserver/fontfaceobserver.js",
+            "assets/js/src/fonts.js"            
+        ],
         main: [
             "assets/js/src/__init.js",
             "assets/js/src/main.js",
@@ -80,7 +84,7 @@ gulp.task("css", ["fonts"], function() {
 });
 
 gulp.task("js", function() {
-    gulp.src(src.js.main).pipe(changed(dist.js)).pipe(addsrc(src.js.vendor)).pipe(concat("" + dist.name + ".js")).pipe(uglify({
+    gulp.src(src.js.fonts).pipe(addsrc(src.js.main)).pipe(changed(dist.js)).pipe(addsrc(src.js.vendor)).pipe(concat("" + dist.name + ".js")).pipe(uglify({
         mangle: false
     })).pipe(header(banner, {
         pkg: pkg
@@ -102,5 +106,6 @@ gulp.task("default", function() {
     gulp.start(["build", "server"]);
     gulp.watch(src.sass.files, ["css"]);
     gulp.watch(src.js.main, ["js"]);
+    gulp.watch(src.js.fonts, ["js"]);
     return gulp.watch(src.js.vendor, ["js"]);
 });

--- a/partials/headscript.hbs
+++ b/partials/headscript.hbs
@@ -1,0 +1,3 @@
+<script type="text/javascript">
+try{var storage=window.sessionStorage;storage&&"1"==storage.getItem("fonts-loaded")&&(window.document.documentElement.className+=" fonts-loaded")}catch(e){}
+</script>


### PR DESCRIPTION
I have been experimenting with improving the font loading experience using WebFontLoader, and FontFaceObserver and I think I've got pretty much the best options here now. 

In order to avoid the Flash of Invisible Text on Safari, I have added explicit fallback fonts, and only use the web fonts once it's finished loading.

This still leaves the Flash of Unstyled Text but I've tried to optimise that too - session storage is used to store a flag to indicate the fonts have already been loaded, and a small script in the head applies the necessary class immediately if necessary which should prevent the FOUT completely on subsequent loads.

What do you think?