### PR TITLE
Fix browser compatibility page

### DIFF
--- a/assets/scss/components/_page-error.scss
+++ b/assets/scss/components/_page-error.scss
@@ -18,12 +18,16 @@ body {
 
     &.page-browser-compatibility {
         @include background-filter;
-        background: url("/assets/img/backgrounds/browser-compatibility.jpg") center/cover no-repeat;
+        background-image: url("/assets/img/backgrounds/browser-compatibility.jpg");
+        background-position: center; 
+        background-repeat: no-repeat;  
+        background-size: cover;  
 
         .error-body {
             text-align: left;
             margin: 100px 20px 20px;
             padding: 20px;
+            background-color: #bbb;
             background-color: rgba(0,0,0,.2);
         }
     }

--- a/default.hbs
+++ b/default.hbs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <!--[if IE 9]>
+        <!--[if lte IE 9]>
         <script type="text/javascript">
             window.location = "/browser-compatibility";
         </script>

--- a/page-browser-compatibility.hbs
+++ b/page-browser-compatibility.hbs
@@ -18,7 +18,7 @@
                 </h1>
                 <hr class="divider short">
                 <h2>
-                     {{meta_title}} runs on the latest Chrome, Firefox, Safari, and IE10+. Your browser is outdated and it may be time to upgrade.
+                     {{@blog.title}} runs on the latest Chrome, Firefox, Safari, and IE10+. Your browser is outdated and it may be time to upgrade.
                 </h2>
                 <div class="call-to-action-container">
                     <nav class="navigation left">


### PR DESCRIPTION
Show the *blog* title on the browser compatibility page instead of the title of the *page*

Redirect to browser-compatibility page when <= IE9 instead of only IE9

Fixes #11 