### PR TITLE
Fix dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,21 +28,21 @@
     "zen"
   ],
   "devDependencies": {
-    "browser-sync": "*",
-    "coffee-script": "*",
-    "gulp": "*",
-    "gulp-add-src": "*",
-    "gulp-autoprefixer": "*",
-    "gulp-changed": "*",
-    "gulp-concat": "*",
-    "gulp-cssmin": "*",
-    "gulp-header": "*",
-    "gulp-minify-css": "*",
-    "gulp-sass": "*",
-    "gulp-strip-css-comments": "*",
-    "gulp-uglify": "*",
-    "gulp-util": "*",
-    "underscore.string": "*"
+    "browser-sync": "2.18.12",
+    "coffee-script": "1.12.6",
+    "gulp": "3.9.1",
+    "gulp-add-src": "0.2.0",
+    "gulp-autoprefixer": "4.0.0",
+    "gulp-changed": "3.1.0",
+    "gulp-concat": "2.6.1",
+    "gulp-cssmin": "0.2.0",
+    "gulp-header": "1.8.8",
+    "gulp-minify-css": "1.2.4",
+    "gulp-sass": "3.1.0",
+    "gulp-strip-css-comments": "1.2.0",
+    "gulp-uglify": "3.0.0",
+    "gulp-util": "3.0.8",
+    "underscore.string": "3.3.4"
   },
   "engines": {
     "node": "~0.10.0 || ~0.12.0 || ^4.2.0"


### PR DESCRIPTION
It is better to use strict versions of the dependencies, it circumvents incompatibility between them or backward incompatibility.